### PR TITLE
Prevent rate limit errors with curl.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,10 +23,10 @@ COMMIT_MESSAGE="${COMMIT_MESSAGE/KUSTOMIZE_IMAGES/$KUSTOMIZE_IMAGES}"
 # Make sure we have a version:
 if [ -z $KUSTOMIZE_VERSION ]; then
     echo "[+] Downloding Kustomize latest version"
-    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+    curl -H "Authorization: Bearer $API_TOKEN_GITHUB" -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 else
     echo "[+] Downloding Kustomize $KUSTOMIZE_VERSION version"
-    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh $KUSTOMIZE_VERSION"  | bash
+    curl -H "Authorization: Bearer $API_TOKEN_GITHUB" -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh $KUSTOMIZE_VERSION"  | bash
 fi
 
 if [ -z "$USER_NAME" ]; then


### PR DESCRIPTION
While downloading kustomize with curl, a github rate limit can be hit because this is an anonymous request from any github actions runner, which is also used by other projects.

By using the ``GITHUB_TOKEN`` provided by github actions, we can let the curl request be authenticated and make the request count towards the rate limit of this generated token, thus prevent rate limits being hit.